### PR TITLE
优化匹配表格格式的正则表达式

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -608,7 +608,7 @@ class Parser
                     break;
 
                 // table
-                case preg_match("/^((?:(?:(?:[ :]*\-[ :]*)+(?:\||\+))|(?:(?:\||\+)(?:[ :]*\-[ :]*)+)|(?:(?:[ :]*\-[ :]*)+(?:\||\+)(?:[ :]*\-[ :]*)+))+)$/", $line, $matches):
+                case preg_match("/^[\|\+]?((?::?\-+:?[\|\+])+(?:\s*:?\-+:?\s*)?)$/", $line, $matches):
                     if ($this->isBlock('table')) {
                         $block[3][0][] = $block[3][2];
                         $block[3][2] ++;


### PR DESCRIPTION
修改前的正则匹配不了 |-|-| 这种表格样式，
修改后的正则更通用一点，可以匹配以下样式：
|-|-|，-|-|-，|-|-，-|-|等全部都可以正确识别
包含对齐操作的表格标记也全部正常～～
